### PR TITLE
Switch to G27 in abort print option

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -1150,7 +1150,7 @@
 
   //#define MENU_ADDAUTOSTART               // Add a menu option to run auto#.g files
 
-  #define EVENT_GCODE_SD_ABORT "G28XY\nM84"      // G-code to run on SD Abort Print (e.g., "G28XY" or "G27")
+  #define EVENT_GCODE_SD_ABORT "G27\nM84"      // G-code to run on SD Abort Print (e.g., "G28XY" or "G27")
 
   #if ENABLED(PRINTER_EVENT_LEDS)
     #define PE_LEDS_COMPLETED_TIME  (30*60) // (seconds) Time to keep the LED "done" color before restoring normal illumination


### PR DESCRIPTION
This prevents the printer from it's current abort behavior that can drag the hot nozzle on the bed and dig in and/or catch the print on it's way to the current G28XY command, especially because bed mesh is no longer respected once performing the cancellation.  This does introduce a problem of the screen freezing on the "Stop Printing?" screen, however this is far preferable to physical damage to the printer and can be solved with a power cycle. Heaters do shut off during this process as expected regardless of the screen state.

### Requirements

* Filling out this template is required. Pull Requests without a clear description may be closed at the maintainers' discretion.

### Description

This prevents the printer from it's current abort behavior that can drag the hot nozzle on the bed and dig in and/or catch the print on it's way to the current G28XY command, especially because bed mesh is no longer respected once performing the cancellation.  This does introduce a problem of the screen freezing on the "Stop Printing?" screen, however this is far preferable to physical damage to the printer and can be solved with a power cycle. Heaters do shut off during this process as expected regardless of the screen state.

### Benefits
Prevents physical damage to printer when using on-screen End Print functionality.
<!-- What does this fix or improve? -->

### Configurations
This is an edit to Configuration_adv.h itself.  Used with existing NOZZLE_PARK_FEATURE settings already in Configuration.h
<!-- Attach any Configuration.h, Configuration_adv.h, or platformio.ini files needed to compile/test your Pull Request. -->

### Related Issues
Closes #12 
<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
