### PR TITLE
Enabled DIRECT_PIN_CONTROL to add M42 to provide LED control

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -3563,7 +3563,7 @@
 //
 // M42 - Set pin states
 //
-//#define DIRECT_PIN_CONTROL
+#define DIRECT_PIN_CONTROL
 
 //
 // M43 - display pin status, toggle pins, watch pins, watch endstops & toggle LED, test servo probe


### PR DESCRIPTION
M42 is also used in Creality FW to control LED

### Requirements

* Filling out this template is required. Pull Requests without a clear description may be closed at the maintainers' discretion.

### Description

Enables DIRECT_PIN_CONTROL which provides M42.
This can be used to control LED via `M42 P6 S<brightness[0-255]>`
Same command can be used in vanilla Creality FW

Addresses #9 (not as pretty/nice as using the dedicated M355 command of course)

### Benefits

<!-- What does this fix or improve? -->

### Configurations

<!-- Attach any Configuration.h, Configuration_adv.h, or platformio.ini files needed to compile/test your Pull Request. -->

### Related Issues

<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
