### PR TITLE
Rename VP_ZPos to VP_Z_OFFSET for clarity

### DIFF
--- a/Marlin/src/lcd/extui/lib/dgus_creality/creality_touch/DGUSDisplayDef.cpp
+++ b/Marlin/src/lcd/extui/lib/dgus_creality/creality_touch/DGUSDisplayDef.cpp
@@ -65,7 +65,7 @@ const uint16_t VPList_Main[] PROGMEM = {
   #if HAS_HEATED_BED
     VP_T_Bed_Is, VP_T_Bed_Set,// VP_BED_STATUS,
   #endif
-  /*VP_XPos, VP_YPos,*/ VP_ZPos,
+  VP_Z_OFFSET,
   //VP_Fan0_Percentage,
   VP_Feedrate_Percentage,
   #if ENABLED(LCD_SET_PROGRESS_MANUALLY)
@@ -81,7 +81,7 @@ const uint16_t VPList_SDFileList[] PROGMEM = {
   #if HAS_HEATED_BED
     VP_T_Bed_Is, VP_T_Bed_Set,// VP_BED_STATUS,
   #endif
-  /*VP_XPos, VP_YPos,*/ VP_ZPos,
+  VP_Z_OFFSET,
   //VP_Fan0_Percentage,
   VP_Feedrate_Percentage,
   #if ENABLED(LCD_SET_PROGRESS_MANUALLY)
@@ -105,7 +105,7 @@ const uint16_t VPList_Control[] PROGMEM = {
   #if HAS_HEATED_BED
     VP_T_Bed_Is, VP_T_Bed_Set,// VP_BED_STATUS,
   #endif
-  /*VP_XPos, VP_YPos,*/ VP_ZPos,
+  VP_Z_OFFSET,
   //VP_Fan0_Percentage,
   VP_Feedrate_Percentage,
   #if ENABLED(LCD_SET_PROGRESS_MANUALLY)
@@ -124,7 +124,7 @@ const uint16_t VPList_Feed[] PROGMEM = {
   #if HAS_HEATED_BED
     VP_T_Bed_Is, VP_T_Bed_Set,// VP_BED_STATUS,
   #endif
-  /*VP_XPos, VP_YPos,*/ VP_ZPos,
+  VP_Z_OFFSET,
   //VP_Fan0_Percentage,
   VP_Feedrate_Percentage,
 
@@ -139,7 +139,7 @@ const uint16_t VPList_Temp[] PROGMEM = {
   #if HAS_HEATED_BED
     VP_T_Bed_Is, VP_T_Bed_Set,// VP_BED_STATUS,
   #endif
-  /*VP_XPos, VP_YPos,*/ VP_ZPos,
+  VP_Z_OFFSET,
   //VP_Fan0_Percentage,
   VP_Feedrate_Percentage,
   #if ENABLED(LCD_SET_PROGRESS_MANUALLY)
@@ -159,7 +159,7 @@ const uint16_t VPList_PreheatPLASettings[] PROGMEM = {
   #if HAS_HEATED_BED
     VP_T_Bed_Is, VP_T_Bed_Set,// VP_BED_STATUS,
   #endif
-  /*VP_XPos, VP_YPos,*/ VP_ZPos,
+  VP_Z_OFFSET,
   //VP_Fan0_Percentage,
   VP_Feedrate_Percentage,
 
@@ -176,7 +176,7 @@ const uint16_t VPList_PreheatABSSettings[] PROGMEM = {
   #if HAS_HEATED_BED
     VP_T_Bed_Is, VP_T_Bed_Set,// VP_BED_STATUS,
   #endif
-  /*VP_XPos, VP_YPos,*/ VP_ZPos,
+  VP_Z_OFFSET,
   //VP_Fan0_Percentage,
   VP_Feedrate_Percentage,
 
@@ -194,7 +194,7 @@ const uint16_t VPList_PrintPausingError[] PROGMEM = {
   #if HAS_HEATED_BED
     VP_T_Bed_Is, VP_T_Bed_Set,// VP_BED_STATUS,
   #endif
-  /*VP_XPos, VP_YPos,*/ VP_ZPos,
+  VP_Z_OFFSET,
   //VP_Fan0_Percentage,
   VP_Feedrate_Percentage,
 
@@ -216,7 +216,7 @@ const uint16_t VPList_PrintScreen[] PROGMEM = {
   #endif
 
   VP_X_POSITION, VP_Y_POSITION, VP_Z_POSITION,
-  VP_ZPos,
+  VP_Z_OFFSET,
   //VP_Fan0_Percentage,
   VP_Feedrate_Percentage,
 
@@ -234,7 +234,7 @@ const uint16_t VPList_Leveling[] PROGMEM = {
   #if HAS_HEATED_BED
     VP_T_Bed_Is, VP_T_Bed_Set,// VP_BED_STATUS,
   #endif
-  /*VP_XPos, VP_YPos,*/ VP_ZPos,
+  VP_Z_OFFSET,
   //VP_Fan0_Percentage,
   VP_Feedrate_Percentage,
 
@@ -250,7 +250,7 @@ const uint16_t VPList_ZOffsetLevel[] PROGMEM = {
   #if HAS_HEATED_BED
     VP_T_Bed_Is, VP_T_Bed_Set,// VP_BED_STATUS,
   #endif
-  /*VP_XPos, VP_YPos,*/ VP_ZPos,
+  VP_Z_OFFSET,
   //VP_Fan0_Percentage,
   VP_Feedrate_Percentage,
 
@@ -266,7 +266,7 @@ const uint16_t VPList_TuneScreen[] PROGMEM = {
   #if HAS_HEATED_BED
     VP_T_Bed_Is, VP_T_Bed_Set,// VP_BED_STATUS,
   #endif
-  /*VP_XPos, VP_YPos,*/ VP_ZPos,
+  VP_Z_OFFSET,
   //VP_Fan0_Percentage,
   VP_Feedrate_Percentage,
 
@@ -286,7 +286,7 @@ const uint16_t VPList_Prepare[] PROGMEM = {
   #if HAS_HEATED_BED
     VP_T_Bed_Is, VP_T_Bed_Set,// VP_BED_STATUS,
   #endif
-  /*VP_XPos, VP_YPos,*/ VP_ZPos,
+  VP_Z_OFFSET,
   //VP_Fan0_Percentage,
   VP_Feedrate_Percentage,
 
@@ -304,7 +304,7 @@ const uint16_t VPList_Info[] PROGMEM = {
   #if HAS_HEATED_BED
     VP_T_Bed_Is, VP_T_Bed_Set,// VP_BED_STATUS,
   #endif
-  /*VP_XPos, VP_YPos,*/ VP_ZPos,
+  VP_Z_OFFSET,
   //VP_Fan0_Percentage,
   VP_Feedrate_Percentage,
 
@@ -432,7 +432,7 @@ const struct DGUS_VP_Variable ListOfVP[] PROGMEM = {
   VPHELPER(VP_Y_POSITION, &current_position.y, ScreenHandler.HandlePositionChange, ScreenHandler.DGUSLCD_SendFloatAsIntValueToDisplay<1>),
   VPHELPER(VP_Z_POSITION, &current_position.z, ScreenHandler.HandlePositionChange, ScreenHandler.DGUSLCD_SendFloatAsIntValueToDisplay<1>),
 
-  VPHELPER(VP_ZPos, &probe.offset.z, ScreenHandler.HandleZoffsetChange, ScreenHandler.DGUSLCD_SendFloatAsIntValueToDisplay<2>),
+  VPHELPER(VP_Z_OFFSET, &probe.offset.z, ScreenHandler.HandleZoffsetChange, ScreenHandler.DGUSLCD_SendFloatAsIntValueToDisplay<2>),
 
   VPHELPER(VP_FAN_TOGGLE, &thermalManager.fan_speed[0], ScreenHandler.HandleFanControl, ScreenHandler.DGUSLCD_SendFanStatusToDisplay),
 

--- a/Marlin/src/lcd/extui/lib/dgus_creality/creality_touch/DGUSDisplayDef.h
+++ b/Marlin/src/lcd/extui/lib/dgus_creality/creality_touch/DGUSDisplayDef.h
@@ -239,12 +239,7 @@ constexpr uint16_t VP_PrintTime_LEN = 6;
 // constexpr uint16_t VP_PrintsTotal = 0x3180;
 // constexpr uint16_t VP_PrintsTotal_LEN = 16;
 
-// // Actual Position
-// constexpr uint16_t VP_XPos = 0x3110;  // 4 Byte Fixed point number; format xxx.yy
-// constexpr uint16_t VP_YPos = 0x3112;  // 4 Byte Fixed point number; format xxx.yy
-constexpr uint16_t VP_ZPos = 0x1026;  // 4 Byte Fixed point number; format xxx.yy - AUTO_BED_LEVEL_ZOFFSET_VP [SD: this is actually Z-offset?]
-
-// constexpr uint16_t VP_EPos = 0x3120;  // 4 Byte Fixed point number; format xxx.yy
+constexpr uint16_t VP_Z_OFFSET = 0x1026;
 
 // // SDCard File Listing
 constexpr uint16_t VP_SD_ScrollEvent = 0x20D4; // Data: 0 for "up a directory", numbers are the amount to scroll, e.g -1 one up, 1 one down


### PR DESCRIPTION
### Requirements


### Description

Rename VP_ZPos to VP_Z_OFFSET for clarity

### Benefits

<!-- What does this fix or improve? -->

### Configurations

<!-- Attach any Configuration.h, Configuration_adv.h, or platformio.ini files needed to compile/test your Pull Request. -->

### Related Issues

<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
