### PR TITLE
Change old u_int8_t to new uint8_t

### DIFF
--- a/Marlin/src/lcd/extui/lib/dgus_creality/DGUSDisplay.cpp
+++ b/Marlin/src/lcd/extui/lib/dgus_creality/DGUSDisplay.cpp
@@ -91,10 +91,10 @@ void DGUSDisplay::ResetDisplay() {
 }
 
 void DGUSDisplay::ReadVariable(uint16_t adr) {
-  WriteHeader(adr, DGUS_CMD_READVAR, sizeof(u_int8_t));
+  WriteHeader(adr, DGUS_CMD_READVAR, sizeof(uint8_t));
 
   // Specify to read one byte
-  dgusserial.write(static_cast<u_int8_t>(1));
+  dgusserial.write(static_cast<uint8_t>(1));
 }
 
 void DGUSDisplay::WriteVariable(uint16_t adr, const void* values, uint8_t valueslen, bool isstr) {


### PR DESCRIPTION
According to:

![image](https://user-images.githubusercontent.com/13086678/100255036-54fb4600-2f43-11eb-8b93-be2cabb3b86e.png)

Made this change to allow the code to be correctly compiled using default_envs = mega2560.
