### PR TITLE
Toggles redesign

### DIFF
--- a/Marlin/src/lcd/extui/lib/dgus_creality/DGUSScreenHandler.h
+++ b/Marlin/src/lcd/extui/lib/dgus_creality/DGUSScreenHandler.h
@@ -227,7 +227,7 @@ public:
   }
 
   // Send an icon to the display, depending on whether it is true or false
-  template<unsigned int value_if_true, unsigned int value_if_false, signed int value_offset>
+  template<unsigned int value_if_true, unsigned int value_if_false, unsigned int value_offset>
   static void DGUSLCD_SendIconValue(DGUS_VP_Variable &var) {
     if (var.memadr) {
       bool value = *(bool *)var.memadr;

--- a/Marlin/src/lcd/extui/lib/dgus_creality/DGUSScreenHandler.h
+++ b/Marlin/src/lcd/extui/lib/dgus_creality/DGUSScreenHandler.h
@@ -227,11 +227,12 @@ public:
   }
 
   // Send an icon to the display, depending on whether it is true or false
-  template<unsigned int value_if_true, unsigned int value_if_false>
+  template<unsigned int value_if_true, unsigned int value_if_false, signed int value_offset>
   static void DGUSLCD_SendIconValue(DGUS_VP_Variable &var) {
     if (var.memadr) {
       bool value = *(bool *)var.memadr;
       uint16_t valueToSend = value ? value_if_true : value_if_false;
+      valueToSend += value_offset;
       dgusdisplay.WriteVariable(var.VP, valueToSend);
     }
   }

--- a/Marlin/src/lcd/extui/lib/dgus_creality/DGUSScreenHandler.h
+++ b/Marlin/src/lcd/extui/lib/dgus_creality/DGUSScreenHandler.h
@@ -227,12 +227,11 @@ public:
   }
 
   // Send an icon to the display, depending on whether it is true or false
-  template<unsigned int value_if_true, unsigned int value_if_false, unsigned int value_offset>
+  template<unsigned int value_if_true, unsigned int value_if_false>
   static void DGUSLCD_SendIconValue(DGUS_VP_Variable &var) {
     if (var.memadr) {
       bool value = *(bool *)var.memadr;
       uint16_t valueToSend = value ? value_if_true : value_if_false;
-      valueToSend += value_offset;
       dgusdisplay.WriteVariable(var.VP, valueToSend);
     }
   }

--- a/Marlin/src/lcd/extui/lib/dgus_creality/creality_touch/DGUSDisplayDef.cpp
+++ b/Marlin/src/lcd/extui/lib/dgus_creality/creality_touch/DGUSDisplayDef.cpp
@@ -493,10 +493,10 @@ const struct DGUS_VP_Variable ListOfVP[] PROGMEM = {
   VPHELPER(VP_STANDBY_BACKLIGHT_TOGGLE, nullptr, ScreenHandler.HandleToggleTouchScreenStandbySetting, nullptr),
 
   // Icons
-  VPHELPER(VP_STEPPERS, &ScreenHandler.are_steppers_enabled, nullptr, (ScreenHandler.DGUSLCD_SendIconValue<ICON_TOGGLE_OFF, ICON_TOGGLE_ON, 0>)),
-  VPHELPER(VP_LED_TOGGLE, &caselight.on, nullptr, (ScreenHandler.DGUSLCD_SendIconValue<ICON_TOGGLE_ON, ICON_TOGGLE_OFF, 2>)),
-  VPHELPER(VP_STANDBY_BACKLIGHT_ICON, &ScreenHandler.Settings.display_standby, nullptr, (ScreenHandler.DGUSLCD_SendIconValue<ICON_TOGGLE_ON, ICON_TOGGLE_OFF, 6>)),
-  VPHELPER(VP_MUTE_ICON, &ScreenHandler.Settings.display_sound, nullptr, (ScreenHandler.DGUSLCD_SendIconValue<ICON_TOGGLE_ON, ICON_TOGGLE_OFF, 4>)),
+  VPHELPER(VP_STEPPERS, &ScreenHandler.are_steppers_enabled, nullptr, (ScreenHandler.DGUSLCD_SendIconValue<ICON_TOGGLE_OFF, ICON_TOGGLE_ON>)),
+  VPHELPER(VP_LED_TOGGLE, &caselight.on, nullptr, (ScreenHandler.DGUSLCD_SendIconValue<ICON_LED_TOGGLE_ON, ICON_LED_TOGGLE_OFF>)),
+  VPHELPER(VP_STANDBY_BACKLIGHT_ICON, &ScreenHandler.Settings.display_standby, nullptr, (ScreenHandler.DGUSLCD_SendIconValue<ICON_STANDBY_TOGGLE_ON, ICON_STANDBY_TOGGLE_OFF>)),
+  VPHELPER(VP_MUTE_ICON, &ScreenHandler.Settings.display_sound, nullptr, (ScreenHandler.DGUSLCD_SendIconValue<ICON_SOUND_TOGGLE_OFF, ICON_SOUND_TOGGLE_ON>)),
 
   // M117 LCD String (We don't need the string in memory but "just" push it to the display on demand, hence the nullptr
   { .VP = VP_M117, .memadr = nullptr, .size = VP_M117_LEN, .set_by_display_handler = nullptr, .send_to_display_handler =&ScreenHandler.DGUSLCD_SendStringToDisplay },

--- a/Marlin/src/lcd/extui/lib/dgus_creality/creality_touch/DGUSDisplayDef.cpp
+++ b/Marlin/src/lcd/extui/lib/dgus_creality/creality_touch/DGUSDisplayDef.cpp
@@ -493,10 +493,10 @@ const struct DGUS_VP_Variable ListOfVP[] PROGMEM = {
   VPHELPER(VP_STANDBY_BACKLIGHT_TOGGLE, nullptr, ScreenHandler.HandleToggleTouchScreenStandbySetting, nullptr),
 
   // Icons
-  VPHELPER(VP_STEPPERS, &ScreenHandler.are_steppers_enabled, nullptr, (ScreenHandler.DGUSLCD_SendIconValue<ICON_TOGGLE_OFF, ICON_TOGGLE_ON>)),
-  VPHELPER(VP_LED_TOGGLE, &caselight.on, nullptr, (ScreenHandler.DGUSLCD_SendIconValue<ICON_TOGGLE_ON, ICON_TOGGLE_OFF>)),
-  VPHELPER(VP_STANDBY_BACKLIGHT_ICON, &ScreenHandler.Settings.display_standby, nullptr, (ScreenHandler.DGUSLCD_SendIconValue<ICON_TOGGLE_ON, ICON_TOGGLE_OFF>)),
-  VPHELPER(VP_MUTE_ICON, &ScreenHandler.Settings.display_sound, nullptr, (ScreenHandler.DGUSLCD_SendIconValue<ICON_TOGGLE_ON, ICON_TOGGLE_OFF>)),
+  VPHELPER(VP_STEPPERS, &ScreenHandler.are_steppers_enabled, nullptr, (ScreenHandler.DGUSLCD_SendIconValue<ICON_TOGGLE_OFF, ICON_TOGGLE_ON, 0>)),
+  VPHELPER(VP_LED_TOGGLE, &caselight.on, nullptr, (ScreenHandler.DGUSLCD_SendIconValue<ICON_TOGGLE_ON, ICON_TOGGLE_OFF, 2>)),
+  VPHELPER(VP_STANDBY_BACKLIGHT_ICON, &ScreenHandler.Settings.display_standby, nullptr, (ScreenHandler.DGUSLCD_SendIconValue<ICON_TOGGLE_ON, ICON_TOGGLE_OFF, 6>)),
+  VPHELPER(VP_MUTE_ICON, &ScreenHandler.Settings.display_sound, nullptr, (ScreenHandler.DGUSLCD_SendIconValue<ICON_TOGGLE_ON, ICON_TOGGLE_OFF, 4>)),
 
   // M117 LCD String (We don't need the string in memory but "just" push it to the display on demand, hence the nullptr
   { .VP = VP_M117, .memadr = nullptr, .size = VP_M117_LEN, .set_by_display_handler = nullptr, .send_to_display_handler =&ScreenHandler.DGUSLCD_SendStringToDisplay },

--- a/Marlin/src/lcd/extui/lib/dgus_creality/creality_touch/DGUSDisplayDef.h
+++ b/Marlin/src/lcd/extui/lib/dgus_creality/creality_touch/DGUSDisplayDef.h
@@ -362,3 +362,13 @@ constexpr uint16_t VP_BUTTON_MOVEKEY = 0x1046;
 // Icons
 constexpr uint16_t ICON_TOGGLE_ON = 1;
 constexpr uint16_t ICON_TOGGLE_OFF = 2;
+
+// Toggles
+constexpr uint16_t ICON_FAN_TOGGLE_ON = 1;
+constexpr uint16_t ICON_FAN_TOGGLE_OFF = 2;
+constexpr uint16_t ICON_LED_TOGGLE_ON = 3;
+constexpr uint16_t ICON_LED_TOGGLE_OFF = 4;
+constexpr uint16_t ICON_SOUND_TOGGLE_ON = 5;
+constexpr uint16_t ICON_SOUND_TOGGLE_OFF = 6;
+constexpr uint16_t ICON_STANDBY_TOGGLE_ON = 7;
+constexpr uint16_t ICON_STANDBY_TOGGLE_OFF = 8;


### PR DESCRIPTION
### Description

Reworked the way toggle buttons are displayed. Instead of having a generic ON/OFF toggle, we can now have custom DwinIcons for each button.

On the screen side, there is a new ICL: 42_Toggles.

On the motherboard side, each toggle is associated with an offset value (image index in ICL = offset + 1 for the ON state and offset + 2 for the OFF state).

`CR6Community/CR-6-touchscreen:extui-dev` is up-to-date with this PR.

### Benefits

We can produce more compact buttons and customize their appearance according to their state (labels, colors and icons can change).

### Configurations

N/A

### Related Issues

Partly with #80.

### Appendix

Toggle example: the "sound" setting.

![5_Sound_on](https://user-images.githubusercontent.com/2005901/103144733-c1c65380-472e-11eb-9ac3-a466caaddfb1.png)

![6_Sound_off](https://user-images.githubusercontent.com/2005901/103144734-c25eea00-472e-11eb-9023-6c27f1b38d3d.png)
