### PR TITLE
Changed marlinui.h include path

### DIFF
--- a/Marlin/src/lcd/extui/lib/dgus_creality/creality_touch/DGUSDisplayDef.cpp
+++ b/Marlin/src/lcd/extui/lib/dgus_creality/creality_touch/DGUSDisplayDef.cpp
@@ -37,7 +37,7 @@
 #include "../../../../../feature/caselight.h"
 
 #include "../../../ui_api.h"
-#include "../../lcd/marlinui.h"
+#include "../../../../marlinui.h"
 
 #include "PageHandlers.h"
 

--- a/Marlin/src/lcd/extui/lib/dgus_creality/creality_touch/PageHandlers.cpp
+++ b/Marlin/src/lcd/extui/lib/dgus_creality/creality_touch/PageHandlers.cpp
@@ -17,7 +17,7 @@
 #include "../../../../../module/settings.h"
 
 #include "../../../ui_api.h"
-#include "../../lcd/marlinui.h"
+#include "../../../../marlinui.h"
 
 #include "PageHandlers.h"
 


### PR DESCRIPTION
Your current repo doesn't compile on atmega2560 based platforms:

![image](https://user-images.githubusercontent.com/13086678/103292457-19461700-49ee-11eb-9682-6437835cf99e.png)

This PR solve the issue