### PR TITLE
Update TOGGLE_PROBE_HEATERS icon

### DIFF
--- a/Marlin/src/lcd/extui/lib/dgus_creality/creality_touch/DGUSDisplayDef.cpp
+++ b/Marlin/src/lcd/extui/lib/dgus_creality/creality_touch/DGUSDisplayDef.cpp
@@ -573,13 +573,12 @@ const struct DGUS_VP_Variable ListOfVP[] PROGMEM = {
 
   #if HAS_PROBE_SETTINGS
   VPHELPER(VP_TOGGLE_PROBE_HEATERS_OFF_ONOFF_BUTTON, nullptr, ScreenHandler.HandleToggleProbeHeaters, nullptr),
-  VPHELPER(VP_TOGGLE_PROBE_HEATERS_OFF_ONOFF_ICON, &probe.settings.turn_heaters_off, nullptr, (ScreenHandler.DGUSLCD_SendIconValue<ICON_TOGGLE_ON, ICON_TOGGLE_OFF>)),
+  VPHELPER(VP_TOGGLE_PROBE_HEATERS_OFF_ONOFF_ICON, &probe.settings.turn_heaters_off, nullptr, (ScreenHandler.DGUSLCD_SendIconValue<ICON_ACCURACY_TOGGLE_ON, ICON_ACCURACY_TOGGLE_OFF>)),
 
   VPHELPER(VP_TOGGLE_PROBE_PREHEAT_HOTEND_TEMP, &probe.settings.preheat_hotend_temp, ScreenHandler.HandleToggleProbePreheatTemp, ScreenHandler.DGUSLCD_SendWordValueToDisplay),
   VPHELPER(VP_TOGGLE_PROBE_PREHEAT_BED_TEMP, &probe.settings.preheat_bed_temp, ScreenHandler.HandleToggleProbePreheatTemp, ScreenHandler.DGUSLCD_SendWordValueToDisplay),
 
   VPHELPER(VP_TOGGLE_PROBE_SETTINGS_NAV_BUTTON, nullptr, (ScreenHandler.DGUSLCD_NavigateToPage<DGUSLCD_SCREEN_LEVELING_SETTINGS>), nullptr),
-
   #endif
 
   // Feed

--- a/Marlin/src/lcd/extui/lib/dgus_creality/creality_touch/DGUSDisplayDef.h
+++ b/Marlin/src/lcd/extui/lib/dgus_creality/creality_touch/DGUSDisplayDef.h
@@ -427,9 +427,10 @@ constexpr uint16_t ICON_SOUND_TOGGLE_ON = 5;
 constexpr uint16_t ICON_SOUND_TOGGLE_OFF = 6;
 constexpr uint16_t ICON_STANDBY_TOGGLE_ON = 7;
 constexpr uint16_t ICON_STANDBY_TOGGLE_OFF = 8;
-
 constexpr uint16_t ICON_FWRETRACT_AUTO_TOGGLE_ON = 9;
 constexpr uint16_t ICON_FWRETRACT_AUTO_TOGGLE_OFF = 10;
+constexpr uint16_t ICON_ACCURACY_TOGGLE_ON = 11;
+constexpr uint16_t ICON_ACCURACY_TOGGLE_OFF = 12;
 
 constexpr uint16_t ICON_FWRETRACT_AUTO_DISENGAGED = 4; // This icon deliberately does not exist
 constexpr uint16_t ICON_FWRETRACT_AUTO_ENGAGED = 3;


### PR DESCRIPTION
### Description

Update the icons ID for VP_TOGGLE_PROBE_HEATERS_OFF_ONOFF_ICON.

### Benefits

It makes the icon "better accuracy" displayed and usable on the screen.
