### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Ensure you take the right assets: the `firmware[suffix].bin`. You should not dow
 
 *Support for the [BTT SKR board](https://damsteen.nl/blog/2020/11/25/how-to-btt-skr-cr6-installation) is also available.*
 
-*Support for the obscure Creality v1.1-ERA board is _not_ available.*
+*Support for the obscure Creality v1.1-ERA board is _not_ verified.  If it is electrically compatible with the Creality 4.5.3, then the 4.5.3 firmware may work.  Please leave us a comment if you have tried that.*
 
 ### Development and compile-it-yourself
 


### PR DESCRIPTION
I have proposed a small edit re: Support for the Creality v1.1.- ERA board, which would update that comment to be consistent with the Release Notes.
I have used the branch/pull request approach to this, so that I can learn how that is done.
Shall I use this same approach when updating the Release Notes for CF 6?

### Requirements

* Filling out this template is required. Pull Requests without a clear description may be closed at the maintainers' discretion.

### Description

The current Readme.md file states that Support for the obscure Creality v1.1-ERA is not provided.
The current Release Notes state that 
"This release of the CR-6 Community Firmware supports the following hardware configurations:
 - Creality CR-6 SE with either a v4.5.2, v4.5.3 or or v1.1-ERA motherboard. "

### Benefits

It seems a shame to discourage potential community members if this firmware actually does work on their machines.
We may be able to recruit one or more new or existing Discord or Facebook group members to test and verify or test and refute the hypothesis that the 4.5.3 version actually works on the 1.1-ERA board.

### Configurations

n/a

### Related Issues

n/a