### PR TITLE
Implement FR - Issue#302

### DIFF
--- a/Marlin/src/lcd/extui/dgus_creality/creality_touch/MeshValidationHandler.cpp
+++ b/Marlin/src/lcd/extui/dgus_creality/creality_touch/MeshValidationHandler.cpp
@@ -69,7 +69,7 @@ void MeshValidationHandler::Start() {
     // Home X and Y so we droop at the side of the bed.
     // G26 with temperature and set for full bed, full pattern, retract 4mm, prime 5mm
     char gcodeBuffer[128] = {0};
-    sprintf_P(gcodeBuffer, PSTR("G90\nG0 X0\nG26 B%d H%d R Q4 P2 X0 Y0"), bed_temperature, nozzle_temperature);
+    sprintf_P(gcodeBuffer, PSTR("G90\nG0 X0\nG26 B%d H%d R Q4 P2 X117 Y117"), bed_temperature, nozzle_temperature);
     queue.inject(gcodeBuffer);
     queue.advance();
 

--- a/Marlin/src/lcd/extui/dgus_creality/creality_touch/MeshValidationHandler.cpp
+++ b/Marlin/src/lcd/extui/dgus_creality/creality_touch/MeshValidationHandler.cpp
@@ -69,7 +69,7 @@ void MeshValidationHandler::Start() {
     // Home X and Y so we droop at the side of the bed.
     // G26 with temperature and set for full bed, full pattern, retract 4mm, prime 5mm
     char gcodeBuffer[128] = {0};
-    sprintf_P(gcodeBuffer, PSTR("G90\nG0 X0\nG26 B%d H%d R Q4 P2 X117 Y117"), bed_temperature, nozzle_temperature);
+    sprintf_P(gcodeBuffer, PSTR("G90\nG0 X0\nG26 B%d H%d R Q4 P15 X117 Y117"), bed_temperature, nozzle_temperature);
     queue.inject(gcodeBuffer);
     queue.advance();
 

--- a/Marlin/src/lcd/extui/dgus_creality/creality_touch/MeshValidationHandler.cpp
+++ b/Marlin/src/lcd/extui/dgus_creality/creality_touch/MeshValidationHandler.cpp
@@ -77,7 +77,7 @@ void MeshValidationHandler::Start() {
     prev_feedrate = ExtUI::getFeedrate_mm_s();
     ExtUI::setFeedrate_mm_s(MESH_VALIDATION_PATTERN_FEEDRATE);
 
-    SetStatusMessage("Starting...");
+    SetStatusMessage("Starting. Prepare tweezers..");
 }
 
 void MeshValidationHandler::Cancel() {

--- a/Marlin/src/lcd/extui/dgus_creality/creality_touch/MeshValidationHandler.cpp
+++ b/Marlin/src/lcd/extui/dgus_creality/creality_touch/MeshValidationHandler.cpp
@@ -69,7 +69,7 @@ void MeshValidationHandler::Start() {
     // Home X and Y so we droop at the side of the bed.
     // G26 with temperature and set for full bed, full pattern, retract 4mm, prime 5mm
     char gcodeBuffer[128] = {0};
-    sprintf_P(gcodeBuffer, PSTR("G90\nG0 X0\nG26 B%d H%d R Q4 P15 X117 Y117"), bed_temperature, nozzle_temperature);
+    sprintf_P(gcodeBuffer, PSTR("G90\nG0 X0\nG26 B%d H%d R Q4 P15 X%d Y%d"), bed_temperature, nozzle_temperature, X_BED_SIZE / 2, Y_BED_SIZE / 2);
     queue.inject(gcodeBuffer);
     queue.advance();
 

--- a/Marlin/src/lcd/extui/dgus_creality/creality_touch/MeshValidationHandler.cpp
+++ b/Marlin/src/lcd/extui/dgus_creality/creality_touch/MeshValidationHandler.cpp
@@ -69,7 +69,7 @@ void MeshValidationHandler::Start() {
     // Home X and Y so we droop at the side of the bed.
     // G26 with temperature and set for full bed, full pattern, retract 4mm, prime 5mm
     char gcodeBuffer[128] = {0};
-    sprintf_P(gcodeBuffer, PSTR("G90\nG0 X0\nG26 B%d H%d R Q4 P15 X117 Y117"), bed_temperature, nozzle_temperature);
+    sprintf_P(gcodeBuffer, PSTR("G90\nG0 X0\nG26 B%d H%d R Q4 P2 X117 Y117"), bed_temperature, nozzle_temperature);
     queue.inject(gcodeBuffer);
     queue.advance();
 


### PR DESCRIPTION
### Description

Increase the amount primed from 2mm to 15mm before drawing the Bed Mesh Validation pattern.
Add a prompt for the user to remind them to get their tweezers ready, to remove the drool and the primed amount, before the extruder begins drawing the pattern.

Implement this change as follows:

Modify line 72 of MeshValidationHandler.cpp to replace P2 with P15
Modify line 80 of MeshValidationHandler.cpp to add "Prepare tweezers" to the "Starting..." message.<!--


### Requirements

No special requirements.

### Benefits

See Issue #302.

### Configurations

Use the CF6.1-Final configs.

### Related Issues

https://github.com/CR6Community/Marlin/issues/302
