### PR TITLE
Use int(G26_RETRACT_MULTIPLIER) in lieu of “4” in MeshValidationHandler.cpp

### DIFF
--- a/Marlin/src/lcd/extui/dgus_creality/creality_touch/MeshValidationHandler.cpp
+++ b/Marlin/src/lcd/extui/dgus_creality/creality_touch/MeshValidationHandler.cpp
@@ -69,7 +69,7 @@ void MeshValidationHandler::Start() {
     // Home X and Y so we droop at the side of the bed.
     // G26 with temperature and set for full bed, full pattern, retract 4mm, prime 5mm
     char gcodeBuffer[128] = {0};
-    sprintf_P(gcodeBuffer, PSTR("G90\nG0 X0\nG26 B%d H%d R Q4 P2 X%d Y%d"), bed_temperature, nozzle_temperature, X_BED_SIZE / 2, Y_BED_SIZE / 2);
+    sprintf_P(gcodeBuffer, PSTR("G90\nG0 X0\nG26 B%d H%d R Q%d P2 X%d Y%d"), bed_temperature, nozzle_temperature, int(G26_RETRACT_MULTIPLIER), X_BED_SIZE / 2, Y_BED_SIZE / 2);
     queue.inject(gcodeBuffer);
     queue.advance();
 


### PR DESCRIPTION

### Description

The current function to Print (Mesh) Validation Pattern is implemented by submitting a G26 command to the planner buffer, with a series of switches defined.

The Q switch, which defines the G26_RETRACT_MULTIPLIER to be used by G26, is currently set to fixed value of “4”. This causes the validation pattern to print using a retraction length of 4mm and an unretract length of 5mm.

A note on the screen (Screen78) states that the function requires a system that can tolerate 6mm of retraction. Systems converted to an all-metal hotend should indeed not use retraction lengths much higher than 1mm, or they risk incurring a nozzle clog.

Some Community Firmware users may not be aware that they should not use higher retraction settings on their systems. Some may just not ”process” the note on the screen. (Don’t ask me how I know that🙄)

In the upstream Marlin GitHub history, https://github.com/MarlinFirmware/Marlin/pull/16511 introduced the variable G26_RETRACT_MULTIPLIER, to answer a user’s request to please, “ Allow to set retraction for UBL mesh test”. Marlin users can now define Q to be any fixed value between 0.05 and 15, in their own Configuration.h file, using that variable.

The CR6 Community Firmware overrides that Configuration.h parameter, by specifying a fixed value of 4 in MeshValidationHandler.cpp.

This Pull Request proposes instead that MeshValidationHandler.cpp be modified to use the Configuration.h parameter.

If a value of 4 should be the default setting for stock CR6 printers, then that parameter should be defined as 4.0 in Configuration.h, not redefined by the code.

### Requirements

This request does not require or assume any particular hardware configuration.  It does, however, seek to align the Community Firmware more closely with the design philosophy of upstream Marlin, which may help users who have multiple machines running Marlin.

### Benefits

The benefit of this proposed change is that users can define the G26_RETRACT_MULTIPLIER parameter value of their choice, by modifying Configuration.h instead of having to find and modify MeshValidationHandler.cpp.

This should make the Print Validation Pattern function available to all users, including those who have since converted their printer to use an all-metal hotend.

### Configurations

Uses the Configuration.h and Configuration_adv.h files included with the latest Release.

### Related Issues

This solution is compatible with Issue #300, in the sense that 
G26_RETRACT_MULTIPLIER can also be user-defined to be the value of the variable RETRACT_LENGTH defined as the default retraction length for FWRETRACT in Configuration_adv.h. (Which, btw, is currently 6.5mm)
